### PR TITLE
Add support for parsing delimiter-separeted-strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,44 @@ console.log(config)
 **NB:** internally this plugin force to not have additional properties,
 so the `additionalProperties` flag is forced to be `false`
 
+### Custom keywords
+This library supports the following Ajv custom keywords:
+
+#### `seperator`
+Type: `string`
+
+Applies to type(s): `string`
+
+When present, the value provided will be split based by this value.
+
+Example:
+```js
+const envSchema = require('env-schema')
+
+const schema = {
+  type: 'object',
+  required: [ 'ALLOWED_HOSTS' ],
+  properties: {
+    ALLOWED_HOSTS: {
+      type: 'string',
+      separator: ','
+    }
+  }
+}
+
+const data = {
+  ALLOWED_HOSTS: '127.0.0.1,0.0.0.0'
+}
+
+const config = envSchema({
+  schema: schema,
+  data: data, // optional, default: process.env
+  dotenv: true // load .env if it's there, default: false
+}) 
+
+// config.data => ['127.0.0.1', '0.0.0.0']
+```
+
 ## Acknowledgements
 
 Kindly sponsored by [Mia Platform](https://www.mia-platform.eu/) and

--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ so the `additionalProperties` flag is forced to be `false`
 ### Custom keywords
 This library supports the following Ajv custom keywords:
 
-#### `seperator`
+#### `separator`
 Type: `string`
 
-Applies to type(s): `string`
+Applies to type: `string`
 
 When present, the value provided will be split based by this value.
 

--- a/index.js
+++ b/index.js
@@ -3,6 +3,20 @@
 const Ajv = require('ajv')
 const ajv = new Ajv({ removeAdditional: true, useDefaults: true, coerceTypes: true })
 
+ajv.addKeyword('separator', {
+  type: 'string',
+  metaSchema: {
+    type: 'string',
+    description: 'value separator'
+  },
+  modifying: true,
+  valid: true,
+  errors: false,
+  compile: (schema) => (data, dataPath, parentData, parentDataProperty) => {
+    parentData[parentDataProperty] = data === '' ? [] : data.split(schema)
+  }
+})
+
 const optsSchema = {
   type: 'object',
   required: ['schema'],

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -228,6 +228,66 @@ const tests = [
     data: [],
     isOk: false,
     errorMessage: 'should NOT have fewer than 1 items,should be object,should match exactly one schema in oneOf'
+  },
+  {
+    name: 'simple object - ok - with separator',
+    schema: {
+      type: 'object',
+      required: ['ALLOWED_HOSTS'],
+      properties: {
+        ALLOWED_HOSTS: {
+          type: 'string',
+          separator: ','
+        }
+      }
+    },
+    data: {
+      ALLOWED_HOSTS: '127.0.0.1,0.0.0.0'
+    },
+    isOk: true,
+    confExpected: {
+      ALLOWED_HOSTS: ['127.0.0.1', '0.0.0.0']
+    }
+  },
+  {
+    name: 'simple object - ok - with separator - only one value',
+    schema: {
+      type: 'object',
+      required: ['ALLOWED_HOSTS'],
+      properties: {
+        ALLOWED_HOSTS: {
+          type: 'string',
+          separator: ','
+        }
+      }
+    },
+    data: {
+      ALLOWED_HOSTS: '127.0.0.1'
+    },
+    isOk: true,
+    confExpected: {
+      ALLOWED_HOSTS: ['127.0.0.1']
+    }
+  },
+  {
+    name: 'simple object - ok - with separator - no values',
+    schema: {
+      type: 'object',
+      required: ['ALLOWED_HOSTS'],
+      properties: {
+        ALLOWED_HOSTS: {
+          type: 'string',
+          separator: ','
+        }
+      }
+    },
+    data: {
+      ALLOWED_HOSTS: ''
+    },
+    isOk: true,
+    confExpected: {
+      ALLOWED_HOSTS: []
+    }
   }
 ]
 

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -288,6 +288,22 @@ const tests = [
     confExpected: {
       ALLOWED_HOSTS: []
     }
+  },
+  {
+    name: 'simple object - KO - with separator',
+    schema: {
+      type: 'object',
+      required: ['ALLOWED_HOSTS'],
+      properties: {
+        ALLOWED_HOSTS: {
+          type: 'string',
+          separator: ','
+        }
+      }
+    },
+    data: {},
+    isOk: false,
+    errorMessage: 'should have required property \'ALLOWED_HOSTS\''
   }
 ]
 


### PR DESCRIPTION
This change allows users to parse environment variables holding lists of values properly. e.g:

* A set of allowed CORS origins
* A set of allowed hosts
* A set of banned IPs

This change relates to #2 in that this is a specialization of a `preprocess` function specific to separating delimited-strings.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
