### PR TITLE
Set ajv option allErrors: true

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Ajv = require('ajv')
-const ajv = new Ajv({ removeAdditional: true, useDefaults: true, coerceTypes: true })
+const ajv = new Ajv({ allErrors: true, removeAdditional: true, useDefaults: true, coerceTypes: true })
 
 ajv.addKeyword('separator', {
   type: 'string',

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -304,6 +304,24 @@ const tests = [
     data: {},
     isOk: false,
     errorMessage: 'should have required property \'ALLOWED_HOSTS\''
+  },
+  {
+    name: 'simple object - KO - multiple required properties',
+    schema: {
+      type: 'object',
+      required: ['A', 'B', 'C'],
+      properties: {
+        A: { type: 'string' },
+        B: { type: 'string' },
+        C: { type: 'string' },
+        D: { type: 'string' }
+      }
+    },
+    data: {},
+    isOk: false,
+    errorMessage: `should have required property 'A'
+should have required property 'B'
+should have required property 'C'`
   }
 ]
 


### PR DESCRIPTION
I want to validate and show errors for all missing environment variables to be able to fix them all at once instead of having to do the fix/restart "dance" a bunch of times before it's all ok.

https://ajv.js.org/docs/api.html#options
"allErrors: check all rules collecting all errors. Default is to return after the first error."