### PR TITLE
chore: add expandEnv to typescript and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ const schema = {
 
 const config = envSchema({
   schema: schema,
-  data: data // optional, default: process.env
-  dotenv: true // load .env if it's there, default: false
+  data: data, // optional, default: process.env
+  dotenv: true, // load .env if it's there, default: false
+  expandEnv: true // use dotenv-expand, default: false
 })
 
 console.log(config)
@@ -51,7 +52,7 @@ const config = envSchema({
   schema: S.object().prop('port', S.string().default('3000').required()),
   data: data, // optional, default: process.env
   dotenv: true, // load .env if it's there, default: false
-  expandEnv: true, // use dotenv-expand, default: false
+  expandEnv: true // use dotenv-expand, default: false
 })
 
 console.log(config)
@@ -92,7 +93,8 @@ const data = {
 const config = envSchema({
   schema: schema,
   data: data, // optional, default: process.env
-  dotenv: true // load .env if it's there, default: false
+  dotenv: true, // load .env if it's there, default: false,
+  expandEnv: true // use dotenv-expand, default: false
 }) 
 
 // config.data => ['127.0.0.1', '0.0.0.0']

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,7 @@ export type EnvSchemaOpt = {
   data?: [EnvSchemaData, ...EnvSchemaData[]] | EnvSchemaData;
   env?: boolean;
   dotenv?: boolean | object;
+  expandEnv?: boolean;
 };
 
 declare function loadAndValidateEnvironment(


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

This adds the `expandEnv` option to the Typescript definition and each example in the `README.md` for consistency.

I upgraded AJV to 8 and when I noticed tests broke based on changed output, it seemed like we should maybe make this a semver major change? If it broke our tests; it could break other folks? The behavior hasn't changed, but, output certainly has.