### PR TITLE
fix(index): support json schema format keyword again

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,6 +54,9 @@ const ajv = new Ajv({
   keywords: [separator]
 })
 
+// Add support for JSON Schema formats to AJV
+require('ajv-formats')(ajv)
+
 const optsSchemaValidator = ajv.compile(optsSchema)
 
 function loadAndValidateEnvironment (_opts) {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "ajv": "^8.0.0",
+    "ajv-formats": "^2.0.1",
     "dotenv": "^8.2.0",
     "dotenv-expand": "^5.1.0"
   },

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -51,6 +51,25 @@ const tests = [
     }
   },
   {
+    name: 'simple object - ok - format keyword',
+    schema: {
+      type: 'object',
+      properties: {
+        EMAIL: {
+          type: 'string',
+          format: 'email'
+        }
+      }
+    },
+    data: {
+      EMAIL: 'example@example.com'
+    },
+    isOk: true,
+    confExpected: {
+      EMAIL: 'example@example.com'
+    }
+  },
+  {
     name: 'simple object - ok - remove additional properties',
     schema: {
       type: 'object',
@@ -305,6 +324,24 @@ const tests = [
     data: {},
     isOk: false,
     errorMessage: 'must have required property \'ALLOWED_HOSTS\''
+  },
+  {
+    name: 'simple object - KO - format keyword',
+    schema: {
+      type: 'object',
+      properties: {
+        EMAIL: {
+          type: 'string',
+          format: 'email'
+        }
+      }
+    },
+    data: {
+      EMAIL: 'example'
+    },
+    isOk: false,
+    // eslint-disable-next-line no-useless-escape
+    errorMessage: 'must match format \"email\"'
   },
   {
     name: 'simple object - KO - multiple required properties',


### PR DESCRIPTION
closes #48 

AJV v6 supported the JSON Schema format keyword however, with v7, this functionality has been moved to a separate module.

This PR simply adds that module.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
