### PR TITLE
Implement support for user supplied ajv instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,42 @@ const schema = {
 
 const config = envSchema({
   schema: schema,
-  data: data // optional, default: process.env
+  data: data, // optional, default: process.env
   dotenv: true // load .env if it is there, default: false
+})
+
+console.log(config)
+// output: { PORT: 3000 }
+```
+
+Optionally, the user can supply their own ajv instance:
+
+```js
+const envSchema = require('env-schema')
+const Ajv = require('ajv')
+
+const schema = {
+  type: 'object',
+  required: [ 'PORT' ],
+  properties: {
+    PORT: {
+      type: 'number',
+      default: 3000
+    }
+  }
+}
+
+const config = envSchema({
+  schema: schema,
+  data: data,
+  dotenv: true,
+  ajv: new Ajv({
+    allErrors: true,
+    removeAdditional: true,
+    useDefaults: true,
+    coerceTypes: true,
+    allowUnionTypes: true
+  })
 })
 
 console.log(config)

--- a/README.md
+++ b/README.md
@@ -132,6 +132,40 @@ const config = envSchema({
 // config.data => ['127.0.0.1', '0.0.0.0']
 ```
 
+The ajv keyword definition objects can be accessed through the property `keywords` on the `envSchema` function:
+
+```js
+const envSchema = require('env-schema')
+const Ajv = require('ajv')
+
+const schema = {
+  type: 'object',
+  properties: {
+    names: {
+      type: 'string',
+      separator: ','
+    }
+  }
+}
+
+const config = envSchema({
+  schema: schema,
+  data: data,
+  dotenv: true,
+  ajv: new Ajv({
+    allErrors: true,
+    removeAdditional: true,
+    useDefaults: true,
+    coerceTypes: true,
+    allowUnionTypes: true,
+    keywords: [envSchema.keywords.separator]
+  })
+})
+
+console.log(config)
+// output: { PORT: 3000 }
+```
+
 ## Acknowledgements
 
 Kindly sponsored by [Mia Platform](https://www.mia-platform.eu/) and

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import Ajv from "ajv";
+import Ajv, { KeywordDefinition } from "ajv";
 
 export type EnvSchemaData = {
   [key: string]: unknown;
@@ -12,9 +12,12 @@ export type EnvSchemaOpt = {
   ajv?: Ajv;
 };
 
-declare function loadAndValidateEnvironment(
-  _opts?: EnvSchemaOpt
-): EnvSchemaData;
+declare const loadAndValidateEnvironment: {
+  (_opts?: EnvSchemaOpt): EnvSchemaData;
+  keywords: {
+    separator: KeywordDefinition;
+  }
+}
 
 export default loadAndValidateEnvironment;
 export { loadAndValidateEnvironment as envSchema };

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+import Ajv from "ajv";
+
 export type EnvSchemaData = {
   [key: string]: unknown;
 };
@@ -7,6 +9,7 @@ export type EnvSchemaOpt = {
   data?: [EnvSchemaData, ...EnvSchemaData[]] | EnvSchemaData;
   env?: boolean;
   dotenv?: boolean | object;
+  ajv?: Ajv;
 };
 
 declare function loadAndValidateEnvironment(

--- a/index.js
+++ b/index.js
@@ -41,11 +41,12 @@ const optsSchema = {
     },
     env: { type: 'boolean', default: true },
     dotenv: { type: ['boolean', 'object'], default: false },
-    expandEnv: { type: ['boolean'], default: false }
+    expandEnv: { type: ['boolean'], default: false },
+    ajv: { type: 'object' }
   }
 }
 
-const ajv = new Ajv({
+const sharedAjvInstance = new Ajv({
   allErrors: true,
   removeAdditional: true,
   useDefaults: true,
@@ -54,7 +55,7 @@ const ajv = new Ajv({
   keywords: [separator]
 })
 
-const optsSchemaValidator = ajv.compile(optsSchema)
+const optsSchemaValidator = sharedAjvInstance.compile(optsSchema)
 
 function loadAndValidateEnvironment (_opts) {
   const opts = Object.assign({}, _opts)
@@ -91,6 +92,8 @@ function loadAndValidateEnvironment (_opts) {
 
   const merge = {}
   data.forEach(d => Object.assign(merge, d))
+
+  const ajv = opts.ajv == null ? sharedAjvInstance : opts.ajv
 
   const valid = ajv.validate(schema, merge)
   if (!valid) {

--- a/index.js
+++ b/index.js
@@ -108,3 +108,4 @@ function loadAndValidateEnvironment (_opts) {
 module.exports = loadAndValidateEnvironment
 module.exports.default = loadAndValidateEnvironment
 module.exports.envSchema = loadAndValidateEnvironment
+module.exports.envSchema.keywords = { separator }

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ const optsSchema = {
     env: { type: 'boolean', default: true },
     dotenv: { type: ['boolean', 'object'], default: false },
     expandEnv: { type: ['boolean'], default: false },
-    ajv: { type: 'object' }
+    ajv: { type: 'object', additionalProperties: true }
   }
 }
 

--- a/test/custom-ajv.test.js
+++ b/test/custom-ajv.test.js
@@ -255,27 +255,25 @@ tests.forEach(function (testConf) {
   })
 })
 
-const noCoercionTest = [
-  {
-    name: 'simple object - not ok - should NOT coerce value',
-    schema: {
-      type: 'object',
-      properties: {
-        PORT: {
-          type: 'integer'
-        }
+const noCoercionTest = {
+  name: 'simple object - not ok - should NOT coerce value',
+  schema: {
+    type: 'object',
+    properties: {
+      PORT: {
+        type: 'integer'
       }
-    },
-    data: {
-      PORT: '44'
-    },
-    isOk: false,
-    errorMessage: 'must be integer',
-    confExpected: {
-      PORT: 44
     }
+  },
+  data: {
+    PORT: '44'
+  },
+  isOk: false,
+  errorMessage: 'must be integer',
+  confExpected: {
+    PORT: 44
   }
-]
+}
 
 const strictValidator = new Ajv({
   allErrors: true,
@@ -283,9 +281,9 @@ const strictValidator = new Ajv({
   useDefaults: true,
   coerceTypes: false,
   allowUnionTypes: true
-})
+});
 
-noCoercionTest.forEach(function (testConf) {
+[noCoercionTest].forEach(function (testConf) {
   t.test(testConf.name, t => {
     const options = {
       schema: testConf.schema,

--- a/test/custom-ajv.test.js
+++ b/test/custom-ajv.test.js
@@ -1,0 +1,300 @@
+'use strict'
+
+const t = require('tap')
+const Ajv = require('ajv')
+const makeTest = require('./make-test')
+const { join } = require('path')
+
+process.env.VALUE_FROM_ENV = 'pippo'
+
+const tests = [
+  {
+    name: 'empty ok',
+    schema: { type: 'object' },
+    data: { },
+    isOk: true,
+    confExpected: {}
+  },
+  {
+    name: 'simple object - ok',
+    schema: {
+      type: 'object',
+      properties: {
+        PORT: {
+          type: 'string'
+        }
+      }
+    },
+    data: {
+      PORT: '44'
+    },
+    isOk: true,
+    confExpected: {
+      PORT: '44'
+    }
+  },
+  {
+    name: 'simple object - ok - coerce value',
+    schema: {
+      type: 'object',
+      properties: {
+        PORT: {
+          type: 'integer'
+        }
+      }
+    },
+    data: {
+      PORT: '44'
+    },
+    isOk: true,
+    confExpected: {
+      PORT: 44
+    }
+  },
+  {
+    name: 'simple object - ok - remove additional properties',
+    schema: {
+      type: 'object',
+      properties: {
+        PORT: {
+          type: 'integer'
+        }
+      }
+    },
+    data: {
+      PORT: '44',
+      ANOTHER_PORT: '55'
+    },
+    isOk: true,
+    confExpected: {
+      PORT: 44
+    }
+  },
+  {
+    name: 'simple object - ok - use default',
+    schema: {
+      type: 'object',
+      properties: {
+        PORT: {
+          type: 'integer',
+          default: 5555
+        }
+      }
+    },
+    data: { },
+    isOk: true,
+    confExpected: {
+      PORT: 5555
+    }
+  },
+  {
+    name: 'simple object - ok - required + default',
+    schema: {
+      type: 'object',
+      required: ['PORT'],
+      properties: {
+        PORT: {
+          type: 'integer',
+          default: 6666
+        }
+      }
+    },
+    data: { },
+    isOk: true,
+    confExpected: {
+      PORT: 6666
+    }
+  },
+  {
+    name: 'simple object - ok - allow array',
+    schema: {
+      type: 'object',
+      required: ['PORT'],
+      properties: {
+        PORT: {
+          type: 'integer',
+          default: 6666
+        }
+      }
+    },
+    data: [{ }],
+    isOk: true,
+    confExpected: {
+      PORT: 6666
+    }
+  },
+  {
+    name: 'simple object - ok - merge multiple object + env',
+    schema: {
+      type: 'object',
+      required: ['PORT', 'MONGODB_URL'],
+      properties: {
+        PORT: {
+          type: 'integer',
+          default: 6666
+        },
+        MONGODB_URL: {
+          type: 'string'
+        },
+        VALUE_FROM_ENV: {
+          type: 'string'
+        }
+      }
+    },
+    data: [{ PORT: 3333 }, { MONGODB_URL: 'mongodb://localhost/pippo' }],
+    isOk: true,
+    confExpected: {
+      PORT: 3333,
+      MONGODB_URL: 'mongodb://localhost/pippo',
+      VALUE_FROM_ENV: 'pippo'
+    }
+  },
+  {
+    name: 'simple object - ok - load only from env',
+    schema: {
+      type: 'object',
+      required: ['VALUE_FROM_ENV'],
+      properties: {
+        VALUE_FROM_ENV: {
+          type: 'string'
+        }
+      }
+    },
+    data: undefined,
+    isOk: true,
+    confExpected: {
+      VALUE_FROM_ENV: 'pippo'
+    }
+  },
+  {
+    name: 'simple object - ok - opts override environment',
+    schema: {
+      type: 'object',
+      required: ['VALUE_FROM_ENV'],
+      properties: {
+        VALUE_FROM_ENV: {
+          type: 'string'
+        }
+      }
+    },
+    data: { VALUE_FROM_ENV: 'pluto' },
+    isOk: true,
+    confExpected: {
+      VALUE_FROM_ENV: 'pluto'
+    }
+  },
+  {
+    name: 'simple object - ok - load only from .env',
+    schema: {
+      type: 'object',
+      required: ['VALUE_FROM_DOTENV'],
+      properties: {
+        VALUE_FROM_DOTENV: {
+          type: 'string'
+        }
+      }
+    },
+    data: undefined,
+    isOk: true,
+    dotenv: { path: join(__dirname, '.env') },
+    confExpected: {
+      VALUE_FROM_DOTENV: 'look ma'
+    }
+  },
+  {
+    name: 'simple object - KO',
+    schema: {
+      type: 'object',
+      required: ['PORT'],
+      properties: {
+        PORT: {
+          type: 'integer'
+        }
+      }
+    },
+    data: { },
+    isOk: false,
+    errorMessage: 'must have required property \'PORT\''
+  },
+  {
+    name: 'simple object - invalid data',
+    schema: {
+      type: 'object',
+      required: ['PORT'],
+      properties: {
+        PORT: {
+          type: 'integer'
+        }
+      }
+    },
+    data: [],
+    isOk: false,
+    errorMessage: 'must NOT have fewer than 1 items,must be object,must match exactly one schema in oneOf'
+  }
+]
+
+const ajv = new Ajv({
+  allErrors: true,
+  removeAdditional: true,
+  useDefaults: true,
+  coerceTypes: true,
+  allowUnionTypes: true
+})
+
+tests.forEach(function (testConf) {
+  t.test(testConf.name, t => {
+    const options = {
+      schema: testConf.schema,
+      data: testConf.data,
+      dotenv: testConf.dotenv,
+      dotenvConfig: testConf.dotenvConfig,
+      ajv
+    }
+
+    makeTest(t, options, testConf.isOk, testConf.confExpected, testConf.errorMessage)
+  })
+})
+
+const noCoercionTest = [
+  {
+    name: 'simple object - not ok - should NOT coerce value',
+    schema: {
+      type: 'object',
+      properties: {
+        PORT: {
+          type: 'integer'
+        }
+      }
+    },
+    data: {
+      PORT: '44'
+    },
+    isOk: false,
+    errorMessage: 'must be integer',
+    confExpected: {
+      PORT: 44
+    }
+  }
+]
+
+const strictValidator = new Ajv({
+  allErrors: true,
+  removeAdditional: true,
+  useDefaults: true,
+  coerceTypes: false,
+  allowUnionTypes: true
+})
+
+noCoercionTest.forEach(function (testConf) {
+  t.test(testConf.name, t => {
+    const options = {
+      schema: testConf.schema,
+      data: testConf.data,
+      dotenv: testConf.dotenv,
+      dotenvConfig: testConf.dotenvConfig,
+      ajv: strictValidator
+    }
+
+    makeTest(t, options, testConf.isOk, testConf.confExpected, testConf.errorMessage)
+  })
+})

--- a/test/types/types.test.ts
+++ b/test/types/types.test.ts
@@ -1,6 +1,6 @@
 import { expectError, expectType } from "tsd";
 import envSchema, { EnvSchemaData, EnvSchemaOpt, envSchema as envSchemaNamed, default as envSchemaDefault } from "../..";
-import Ajv from 'ajv'
+import Ajv, { KeywordDefinition } from 'ajv'
 
 const schema = {
   type: "object",
@@ -61,3 +61,4 @@ const optWithAjvInstance: EnvSchemaOpt = {
   ajv: new Ajv()
 };
 expectType<EnvSchemaOpt>(optWithAjvInstance)
+expectType<KeywordDefinition>(envSchema.keywords.separator)

--- a/test/types/types.test.ts
+++ b/test/types/types.test.ts
@@ -1,5 +1,6 @@
 import { expectError, expectType } from "tsd";
 import envSchema, { EnvSchemaData, EnvSchemaOpt, envSchema as envSchemaNamed, default as envSchemaDefault } from "../..";
+import Ajv from 'ajv'
 
 const schema = {
   type: "object",
@@ -55,3 +56,8 @@ const optWithDotEnvOpt: EnvSchemaOpt = {
   dotenv: true,
 };
 expectType<EnvSchemaOpt>(optWithDotEnvOpt);
+
+const optWithAjvInstance: EnvSchemaOpt = {
+  ajv: new Ajv()
+};
+expectType<EnvSchemaOpt>(optWithAjvInstance)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

#### Description

Implements requested feature in #72 , with this PR the users can supply their own instance of ajv, i originally wanted to implement the `current` keyword too but the issue was not clear on what the keyword does or how it should be implemented.