### PR TITLE
Use Ajv.errorsText instead of custom error message

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ function loadAndValidateEnvironment (_opts) {
 
   const isOptionValid = optsSchemaValidator(opts)
   if (!isOptionValid) {
-    const error = new Error(optsSchemaValidator.errors.map(e => e.message))
+    const error = new Error(sharedAjvInstance.errorsText(optsSchemaValidator.errors, { dataVar: 'opts' }))
     error.errors = optsSchemaValidator.errors
     throw error
   }
@@ -97,7 +97,7 @@ function loadAndValidateEnvironment (_opts) {
 
   const valid = ajv.validate(schema, merge)
   if (!valid) {
-    const error = new Error(ajv.errors.map(e => e.message).join('\n'))
+    const error = new Error(ajv.errorsText(ajv.errors, { dataVar: 'env' }))
     error.errors = ajv.errors
     throw error
   }

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -213,7 +213,7 @@ const tests = [
     },
     data: { },
     isOk: false,
-    errorMessage: 'must have required property \'PORT\''
+    errorMessage: 'env must have required property \'PORT\''
   },
   {
     name: 'simple object - invalid data',
@@ -228,7 +228,7 @@ const tests = [
     },
     data: [],
     isOk: false,
-    errorMessage: 'must NOT have fewer than 1 items,must be object,must match exactly one schema in oneOf'
+    errorMessage: 'opts/data must NOT have fewer than 1 items, opts/data must be object, opts/data must match exactly one schema in oneOf'
   },
   {
     name: 'simple object - ok - with separator',
@@ -304,7 +304,7 @@ const tests = [
     },
     data: {},
     isOk: false,
-    errorMessage: 'must have required property \'ALLOWED_HOSTS\''
+    errorMessage: 'env must have required property \'ALLOWED_HOSTS\''
   },
   {
     name: 'simple object - KO - multiple required properties',
@@ -320,9 +320,7 @@ const tests = [
     },
     data: {},
     isOk: false,
-    errorMessage: `must have required property 'A'
-must have required property 'B'
-must have required property 'C'`
+    errorMessage: 'env must have required property \'A\', env must have required property \'B\', env must have required property \'C\''
   }
 ]
 

--- a/test/custom-ajv.test.js
+++ b/test/custom-ajv.test.js
@@ -214,7 +214,7 @@ const tests = [
     },
     data: { },
     isOk: false,
-    errorMessage: 'must have required property \'PORT\''
+    errorMessage: 'env must have required property \'PORT\''
   },
   {
     name: 'simple object - invalid data',
@@ -229,7 +229,7 @@ const tests = [
     },
     data: [],
     isOk: false,
-    errorMessage: 'must NOT have fewer than 1 items,must be object,must match exactly one schema in oneOf'
+    errorMessage: 'opts/data must NOT have fewer than 1 items, opts/data must be object, opts/data must match exactly one schema in oneOf'
   }
 ]
 
@@ -269,7 +269,7 @@ const noCoercionTest = {
     PORT: '44'
   },
   isOk: false,
-  errorMessage: 'must be integer',
+  errorMessage: 'env/PORT must be integer',
   confExpected: {
     PORT: 44
   }


### PR DESCRIPTION
This provides context to the message you are getting, instead of just saying must be an integer, from now on you will get env/VARIABLE must be an integer.

closes #78

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added (not necessary improves existing functionality)
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
