### PR TITLE
feat: envSchema allows specifying return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,41 @@ console.log(config)
 // output: { PORT: 3000 }
 ```
 
+### TypeScript
+
+You can specify the type of your `config`:
+
+```ts
+import envSchema from 'env-schema';
+
+interface Env {
+  PORT: string
+}
+
+const schema = {
+  type: 'object',
+  required: [ 'PORT' ],
+  properties: {
+    PORT: {
+      type: 'number',
+      default: 3000
+    }
+  }
+};
+
+const config = envSchema<Env>({
+  schema,
+})
+```
+
+If no type is specified the `config` will have the `EnvSchemaData` type.
+
+```ts
+export type EnvSchemaData = {
+  [key: string]: unknown;
+};
+```
+
 ## Acknowledgements
 
 Kindly sponsored by [Mia Platform](https://www.mia-platform.eu/) and

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,7 +13,7 @@ export type EnvSchemaOpt = {
 };
 
 declare const loadAndValidateEnvironment: {
-  (_opts?: EnvSchemaOpt): EnvSchemaData;
+  <T = EnvSchemaData>(_opts?: EnvSchemaOpt): T;
   keywords: {
     separator: KeywordDefinition;
   }

--- a/test/types/types.test.ts
+++ b/test/types/types.test.ts
@@ -62,3 +62,12 @@ const optWithAjvInstance: EnvSchemaOpt = {
 };
 expectType<EnvSchemaOpt>(optWithAjvInstance)
 expectType<KeywordDefinition>(envSchema.keywords.separator)
+
+const envSchemaDefaultsToEnvSchemaData = envSchema({ schema: schema });
+expectType<EnvSchemaData>(envSchemaDefaultsToEnvSchemaData)
+
+interface EnvData {
+  PORT: string
+}
+const envSchemaAllowsToSpecifyType = envSchema<EnvData>({ schema });
+expectType<EnvData>(envSchemaAllowsToSpecifyType)


### PR DESCRIPTION
Adjust typing so that calling envSchema defaults to EnvSchemaData if no type is specified but it can be specified using a generic param and add a section to the readme.

closes #84 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
