### PR TITLE
add expandEnv to typescript definition, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,17 @@ const config = envSchema({
   schema: schema,
   data: data, // optional, default: process.env
   dotenv: true // load .env if it is there, default: false
+  // or you can pass DotenvConfigOptions
+  // dotenv: {
+  //   path: '/custom/path/to/.env'
+  // }
 })
 
 console.log(config)
 // output: { PORT: 3000 }
 ```
+
+see [DotenvConfigOptions](https://github.com/motdotla/dotenv#options)
 
 Optionally, the user can supply their own ajv instance:
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,5 @@
 import Ajv, { KeywordDefinition } from "ajv";
+import { DotenvConfigOptions } from "dotenv";
 
 export type EnvSchemaData = {
   [key: string]: unknown;
@@ -8,7 +9,8 @@ export type EnvSchemaOpt = {
   schema?: object;
   data?: [EnvSchemaData, ...EnvSchemaData[]] | EnvSchemaData;
   env?: boolean;
-  dotenv?: boolean | object;
+  dotenv?: boolean | DotenvConfigOptions;
+  expandEnv?: boolean
   ajv?: Ajv;
 };
 

--- a/test/types/types.test.ts
+++ b/test/types/types.test.ts
@@ -53,9 +53,14 @@ const optWithDotEnvBoolean: EnvSchemaOpt = {
 expectType<EnvSchemaOpt>(optWithDotEnvBoolean);
 
 const optWithDotEnvOpt: EnvSchemaOpt = {
-  dotenv: true,
+  dotenv: {},
 };
 expectType<EnvSchemaOpt>(optWithDotEnvOpt);
+
+const optWithEnvExpand: EnvSchemaOpt = {
+  expandEnv: true
+}
+expectType<EnvSchemaOpt>(optWithEnvExpand);
 
 const optWithAjvInstance: EnvSchemaOpt = {
   ajv: new Ajv()


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

add the missing `expandEnv` to the typescript definition from PR #36 , and use `DotenvConfigOptions` instead of `object`

there's already PR #51, but I decided to open a new one