### PR TITLE
fix add ajv format by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const Ajv = require('ajv')
+const addFormats = require('ajv-formats')
 
 const separator = {
   keyword: 'separator',
@@ -54,6 +55,7 @@ const sharedAjvInstance = new Ajv({
   allowUnionTypes: true,
   keywords: [separator]
 })
+addFormats(sharedAjvInstance)
 
 const optsSchemaValidator = sharedAjvInstance.compile(optsSchema)
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Validate your env variable using Ajv and dotenv",
   "main": "index.js",
   "scripts": {
+    "lint:fix": "standard --fix",
     "test": "standard | snazzy && tap test/*.test.js --no-check-coverage && npm run typescript",
     "test:ci": "standard | snazzy && tap test/*.test.js --no-check-coverage --coverage-report=lcovonly && npm run typescript",
     "typescript": "tsd"
@@ -37,6 +38,7 @@
   },
   "dependencies": {
     "ajv": "^8.0.0",
+    "ajv-formats": "^2.1.1",
     "dotenv": "^10.0.0",
     "dotenv-expand": "^5.1.0"
   },

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -321,6 +321,23 @@ const tests = [
     data: {},
     isOk: false,
     errorMessage: 'env must have required property \'A\', env must have required property \'B\', env must have required property \'C\''
+  },
+  {
+    name: 'schema within format',
+    schema: {
+      type: 'object',
+      required: ['DB_URI'],
+      properties: {
+        DB_URI: { type: 'string', format: 'uri' }
+      }
+    },
+    data: {
+      DB_URI: 'mongodb://localhost/foo'
+    },
+    isOk: true,
+    confExpected: {
+      DB_URI: 'mongodb://localhost/foo'
+    }
   }
 ]
 


### PR DESCRIPTION
By default ajv7 and 8 have dropped the `format` keyword.

This pr add the support for it (it is the default on fastify v4 too)

