### PR TITLE
feat: Ajv enhance

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ console.log(config)
 
 see [DotenvConfigOptions](https://github.com/motdotla/dotenv#options)
 
+### Custom ajv instance
+
 Optionally, the user can supply their own ajv instance:
 
 ```js
@@ -80,6 +82,27 @@ const config = envSchema({
 console.log(config)
 // output: { PORT: 3000 }
 ```
+
+It is possible to enhance the default ajv instance providing the `customOptions` function parameter.
+This example shows how to use the `format` keyword in your schemas.
+
+```js
+const config = envSchema({
+  schema: schema,
+  data: data,
+  dotenv: true,
+  ajv: {
+    customOptions (ajvInstance) {
+      require('ajv-formats')(ajvInstance)
+      return ajvInstance
+    }
+  }
+})
+```
+
+Note that it is mandatory returning the ajv instance.
+
+### Fluent-Schema API
 
 It is also possible to use [fluent-json-schema](http://npm.im/fluent-json-schema):
 

--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ function chooseAjvInstance (defaultInstance, ajvOpts) {
     return defaultInstance
   } else if (typeof ajvOpts === 'object' && typeof ajvOpts.customOptions === 'function') {
     const ajv = ajvOpts.customOptions(getDefaultInstance())
-    if (!ajv) {
+    if (!(ajv instanceof Ajv)) {
       throw new Error('customOptions function must return an instance of Ajv')
     }
     return ajv

--- a/index.js
+++ b/index.js
@@ -46,14 +46,7 @@ const optsSchema = {
   }
 }
 
-const sharedAjvInstance = new Ajv({
-  allErrors: true,
-  removeAdditional: true,
-  useDefaults: true,
-  coerceTypes: true,
-  allowUnionTypes: true,
-  keywords: [separator]
-})
+const sharedAjvInstance = getDefaultInstance()
 
 const optsSchemaValidator = sharedAjvInstance.compile(optsSchema)
 
@@ -93,7 +86,7 @@ function loadAndValidateEnvironment (_opts) {
   const merge = {}
   data.forEach(d => Object.assign(merge, d))
 
-  const ajv = opts.ajv == null ? sharedAjvInstance : opts.ajv
+  const ajv = chooseAjvInstance(sharedAjvInstance, opts.ajv)
 
   const valid = ajv.validate(schema, merge)
   if (!valid) {
@@ -103,6 +96,26 @@ function loadAndValidateEnvironment (_opts) {
   }
 
   return merge
+}
+
+function chooseAjvInstance (defaultInstance, ajvOpts) {
+  if (!ajvOpts) {
+    return defaultInstance
+  } else if (typeof ajvOpts === 'object' && typeof ajvOpts.customOptions === 'function') {
+    return ajvOpts.customOptions(getDefaultInstance())
+  }
+  return ajvOpts
+}
+
+function getDefaultInstance () {
+  return new Ajv({
+    allErrors: true,
+    removeAdditional: true,
+    useDefaults: true,
+    coerceTypes: true,
+    allowUnionTypes: true,
+    keywords: [separator]
+  })
 }
 
 module.exports = loadAndValidateEnvironment

--- a/index.js
+++ b/index.js
@@ -102,7 +102,11 @@ function chooseAjvInstance (defaultInstance, ajvOpts) {
   if (!ajvOpts) {
     return defaultInstance
   } else if (typeof ajvOpts === 'object' && typeof ajvOpts.customOptions === 'function') {
-    return ajvOpts.customOptions(getDefaultInstance())
+    const ajv = ajvOpts.customOptions(getDefaultInstance())
+    if (!ajv) {
+      throw new Error('customOptions function must return an instance of Ajv')
+    }
+    return ajv
   }
   return ajvOpts
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "homepage": "https://github.com/fastify/env-schema#readme",
   "devDependencies": {
+    "ajv-formats": "^2.1.1",
     "fluent-json-schema": "^3.0.0",
     "pre-commit": "^1.2.2",
     "snazzy": "^9.0.0",

--- a/test/custom-ajv.test.js
+++ b/test/custom-ajv.test.js
@@ -296,3 +296,35 @@ const strictValidator = new Ajv({
     makeTest(t, options, testConf.isOk, testConf.confExpected, testConf.errorMessage)
   })
 })
+
+t.test('ajv enhancement', t => {
+  const testCase = {
+    schema: {
+      type: 'object',
+      required: ['MONGODB_URL'],
+      properties: {
+        MONGODB_URL: {
+          type: 'string',
+          format: 'uri'
+        }
+      }
+    },
+    data: [{ PORT: 3333 }, { MONGODB_URL: 'mongodb://localhost/pippo' }],
+    isOk: true,
+    confExpected: {
+      MONGODB_URL: 'mongodb://localhost/pippo'
+    }
+  }
+
+  const options = {
+    schema: testCase.schema,
+    data: testCase.data,
+    ajv: {
+      customOptions (ajvInstance) {
+        require('ajv-formats')(ajvInstance)
+        return ajvInstance
+      }
+    }
+  }
+  makeTest(t, options, testCase.isOk, testCase.confExpected)
+})

--- a/test/custom-ajv.test.js
+++ b/test/custom-ajv.test.js
@@ -298,6 +298,7 @@ const strictValidator = new Ajv({
 })
 
 t.test('ajv enhancement', t => {
+  t.plan(2)
   const testCase = {
     schema: {
       type: 'object',
@@ -316,15 +317,30 @@ t.test('ajv enhancement', t => {
     }
   }
 
-  const options = {
-    schema: testCase.schema,
-    data: testCase.data,
-    ajv: {
-      customOptions (ajvInstance) {
-        require('ajv-formats')(ajvInstance)
-        return ajvInstance
+  t.test('return', t => {
+    const options = {
+      schema: testCase.schema,
+      data: testCase.data,
+      ajv: {
+        customOptions (ajvInstance) {
+          require('ajv-formats')(ajvInstance)
+          return ajvInstance
+        }
       }
     }
-  }
-  makeTest(t, options, testCase.isOk, testCase.confExpected)
+    makeTest(t, options, testCase.isOk, testCase.confExpected)
+  })
+
+  t.test('no return', t => {
+    const options = {
+      schema: testCase.schema,
+      data: testCase.data,
+      ajv: {
+        customOptions (ajvInstance) {
+          // do nothing
+        }
+      }
+    }
+    makeTest(t, options, false, undefined, 'customOptions function must return an instance of Ajv')
+  })
 })


### PR DESCRIPTION
followup PR #92 #52 

This interface uses the same pattern used by fastify to customize the ajv configuration.

Right now the `customOptions` accepts a JSON only, but using it as a function we can ease the setup of the ajv instance.

Then we could add this same interface to [`ajv-compiler`](https://github.com/fastify/ajv-compiler#fastifyajv-compiler) too