### PR TITLE
docs: fix 'PORT' datatype in the usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ const schema = {
   required: [ 'PORT' ],
   properties: {
     PORT: {
-      type: 'string',
+      type: 'number',
       default: 3000
     }
   }

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ const envSchema = require('env-schema')
 const S = require('fluent-json-schema')
 
 const config = envSchema({
-  schema: S.object().prop('port', S.number().default('3000').required()),
+  schema: S.object().prop('port', S.number().default(3000).required()),
   data: data, // optional, default: process.env
   dotenv: true, // load .env if it is there, default: false
   expandEnv: true, // use dotenv-expand, default: false

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ You can specify the type of your `config`:
 import envSchema from 'env-schema';
 
 interface Env {
-  PORT: string
+  PORT: number;
 }
 
 const schema = {

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ const config = envSchema({
 })
 
 console.log(config)
-// output: { PORT: 3000 }
+// output: { names: ['foo', 'bar'] }
 ```
 
 ### TypeScript

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ const envSchema = require('env-schema')
 const S = require('fluent-json-schema')
 
 const config = envSchema({
-  schema: S.object().prop('port', S.string().default('3000').required()),
+  schema: S.object().prop('port', S.number().default('3000').required()),
   data: data, // optional, default: process.env
   dotenv: true, // load .env if it is there, default: false
   expandEnv: true, // use dotenv-expand, default: false

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ const schema = {
       default: 3000
     }
   }
-};
+}
 
 const config = envSchema<Env>({
   schema,
@@ -227,7 +227,7 @@ If no type is specified the `config` will have the `EnvSchemaData` type.
 ```ts
 export type EnvSchemaData = {
   [key: string]: unknown;
-};
+}
 ```
 
 ## Acknowledgements


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
Adjust `PORT` datatype to the default value and the expected `console.log` output.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
