### PR TITLE
fix: global ajv cache

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,6 +118,7 @@ function getDefaultInstance () {
     useDefaults: true,
     coerceTypes: true,
     allowUnionTypes: true,
+    addUsedSchema: false,
     keywords: [separator]
   })
 }

--- a/test/no-global.test.js
+++ b/test/no-global.test.js
@@ -1,9 +1,9 @@
 'use strict'
 
-const t = require('tap')
+const { test } = require('tap')
 const envSchema = require('../index')
 
-t.test('no globals', t => {
+test('no globals', t => {
   t.plan(2)
 
   const options = {

--- a/test/no-global.test.js
+++ b/test/no-global.test.js
@@ -1,0 +1,38 @@
+'use strict'
+
+const t = require('tap')
+const envSchema = require('../index')
+
+t.test('no globals', t => {
+  t.plan(2)
+
+  const options = {
+    confKey: 'secrets',
+    data: {
+      MONGO_URL: 'good'
+    },
+    schema: {
+      $id: 'schema:dotenv',
+      type: 'object',
+      required: ['MONGO_URL'],
+      properties: {
+        PORT: {
+          type: 'integer',
+          default: 3000
+        },
+        MONGO_URL: {
+          type: 'string'
+        }
+      }
+    }
+  }
+
+  {
+    const conf = envSchema(JSON.parse(JSON.stringify(options)))
+    t.strictSame(conf, { MONGO_URL: 'good', PORT: 3000 })
+  }
+  {
+    const conf = envSchema(JSON.parse(JSON.stringify(options)))
+    t.strictSame(conf, { MONGO_URL: 'good', PORT: 3000 })
+  }
+})


### PR DESCRIPTION
I faced this issue when I was using this plugin in tests:

```
fastify.register(fastifyEnv, {
      confKey: 'secrets',
      data: opts.configData,
      schema: fastify.getSchema('schema:dotenv')
    })
```

This plugin has a global ajv instance that is caching the schemas.
This cache trigger this error:

```
Subtest: the application should start
    not ok 1 - schema with key or id "schema:dotenv" already exists
      ---
      stack: |
        Ajv._checkUnique (node_modules/env-schema/node_modules/ajv/lib/core.ts:721:13)
```

This change turns off the cache because the schema provided to the `env-schema` is single and it does not require the cache used by ajv.

https://ajv.js.org/options.html#addusedschema