### PR TITLE
chore: remove unnecessary arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,18 +12,8 @@ const separator = {
   modifying: true,
   valid: true,
   errors: false,
-  compile: (schema) => (data, dataPath, parentData, parentDataProperty) => {
-    // In some cases parentData and parentDataProperty will be undefined.
-    // We need to fall back to the dataPath object to provide those values.
-    if (parentData && parentDataProperty) {
-      parentData[parentDataProperty] = data === '' ? [] : data.split(schema)
-    } else {
-      const {
-        parentData: pData,
-        parentDataProperty: pDataProperty
-      } = dataPath
-      pData[pDataProperty] = data === '' ? [] : data.split(schema)
-    }
+  compile: (schema) => (data, { parentData: pData, parentDataProperty: pDataProperty }) => {
+    pData[pDataProperty] = data === '' ? [] : data.split(schema)
   }
 }
 


### PR DESCRIPTION
This PR removes unnecessary arguments and improves test coverage.

In #40, a workaround is added to avoid the undefined error.
It says "In some cases" but it is actually "In all cases" because the arguments are changed in v7.
Ref: https://github.com/ajv-validator/ajv/commit/9e2e6b99380d4d37d6cb5a22a8059aa38f9c1957#diff-489d67aa91e09063da5c34330526703a13b3cdedf7d86426173d0bc62183b6c7L36-L50

Now there are 2 arguments `data` and `dataCxt`.
Ref: https://github.com/ajv-validator/ajv/blob/master/lib/types/index.ts#L50-L57
Ref2: https://github.com/ajv-validator/ajv/blob/master/lib/vocabularies/code.ts#L75-L91

Therefore, I guess we can remove the if statement.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
