### PR TITLE
Fix typescript error due to schema type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,7 +1,6 @@
 import Ajv, { KeywordDefinition, JSONSchemaType } from 'ajv';
 import { AnySchema } from 'ajv/dist/core';
 import { DotenvConfigOptions } from 'dotenv';
-import { ObjectSchema } from 'fluent-json-schema';
 
 export type { JSONSchemaType };
 
@@ -10,7 +9,7 @@ export type EnvSchemaData = {
 };
 
 export type EnvSchemaOpt<T = EnvSchemaData> = {
-  schema?: JSONSchemaType<T> | AnySchema | ObjectSchema;
+  schema?: JSONSchemaType<T> | AnySchema;
   data?: [EnvSchemaData, ...EnvSchemaData[]] | EnvSchemaData;
   env?: boolean;
   dotenv?: boolean | DotenvConfigOptions;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

### Description:

Schema type was changed in pull request #134. One of the available schema types was `ObjectSchema` from `fluent-json-schema` package. Since `fluent-json-schema` is a development dependency, we cannot use it for production code

Now, if we do not install `fluent-json-schema` manually, we will get the wrong type for schema, or an error if we use `"skipLibCheck": false` in the typescript config file

After this fix, we can still use `fluent-json-schema`, but we will not get wrong type or error if this package is missing
