### PR TITLE
Return previous schema type

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ const schema: JSONSchemaType<Env> = {
   }
 }
 
-const config = envSchema({
+const config = envSchema<Env>({
   schema
 })
 ```

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,4 @@
 import Ajv, { KeywordDefinition, JSONSchemaType } from 'ajv';
-import { AnySchema } from 'ajv/dist/core';
 import { DotenvConfigOptions } from 'dotenv';
 
 type EnvSchema = typeof envSchema
@@ -11,8 +10,8 @@ declare namespace envSchema {
     [key: string]: unknown;
   };
 
-  export type EnvSchemaOpt<T = EnvSchemaData> = {
-    schema?: JSONSchemaType<T> | AnySchema;
+  export type EnvSchemaOpt = {
+    schema?: object;
     data?: [EnvSchemaData, ...EnvSchemaData[]] | EnvSchemaData;
     env?: boolean;
     dotenv?: boolean | DotenvConfigOptions;
@@ -32,5 +31,5 @@ declare namespace envSchema {
   export { envSchema as default }
 }
 
-declare function envSchema<T = envSchema.EnvSchemaData>(_opts?: envSchema.EnvSchemaOpt<T>): T
+declare function envSchema<T = envSchema.EnvSchemaData>(_opts?: envSchema.EnvSchemaOpt): T
 export = envSchema

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -8,6 +8,7 @@ import envSchema, {
 } from '..';
 import Ajv, { KeywordDefinition, JSONSchemaType } from 'ajv';
 import { Static, Type } from '@sinclair/typebox';
+import S from 'fluent-json-schema';
 
 interface EnvData {
   PORT: number;
@@ -23,6 +24,11 @@ const schemaWithType: JSONSchemaType<EnvData> = {
     },
   },
 };
+
+const schemaFluent = S.object().prop(
+  'PORT',
+  S.number().default(3000).required()
+);
 
 const schemaTypebox = Type.Object({
   PORT: Type.Number({ default: 3000 }),
@@ -41,15 +47,20 @@ expectType<EnvSchemaData>(envSchemaDefault());
 const emptyOpt: EnvSchemaOpt = {};
 expectType<EnvSchemaOpt>(emptyOpt);
 
+const optWithSchemaFluent: EnvSchemaOpt = {
+  schema: schemaFluent,
+};
+expectType<EnvSchemaOpt>(optWithSchemaFluent);
+
 const optWithSchemaTypebox: EnvSchemaOpt = {
   schema: schemaTypebox,
 };
 expectType<EnvSchemaOpt>(optWithSchemaTypebox);
 
-const optWithSchemaWithType: EnvSchemaOpt<EnvData> = {
+const optWithSchemaWithType: EnvSchemaOpt = {
   schema: schemaWithType,
 };
-expectType<EnvSchemaOpt<EnvData>>(optWithSchemaWithType);
+expectType<EnvSchemaOpt>(optWithSchemaWithType);
 
 const optWithData: EnvSchemaOpt = {
   data,
@@ -105,11 +116,11 @@ expectError<EnvSchemaOpt>({
   },
 });
 
-const envSchemaWithType = envSchema({ schema: schemaWithType });
+const envSchemaWithType = envSchema<EnvData>({ schema: schemaWithType });
 expectType<EnvData>(envSchemaWithType);
 
 const envSchemaTypebox = envSchema<SchemaTypebox>({ schema: schemaTypebox });
 expectType<SchemaTypebox>(envSchemaTypebox);
 
-expectType<KeywordDefinition>(keywords.separator)
-expectType<KeywordDefinition>(envSchema.keywords.separator)
+expectType<KeywordDefinition>(keywords.separator);
+expectType<KeywordDefinition>(envSchema.keywords.separator);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

### Description:

As discussed in #138, `env-schema` should support `fluent-json-schema` library out-of-the-box (without explicitly calling `valueOf` method). Given this requirement, we cannot use a narrower type for schema (reasons why we cannot use code from `fluent-json-schema` are described in #137)

In future, if we remove this requirement, it will be possible to return a more strict type