### PR TITLE
fix: correct expandEnv bug when passing in a new object in the data option

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,14 +68,15 @@ function envSchema (_opts) {
 
   /* istanbul ignore else */
   if (env) {
-    if (expandEnv) {
-      require('dotenv-expand').expand({ parsed: process.env })
-    }
     data.unshift(process.env)
   }
 
   const merge = {}
   data.forEach(d => Object.assign(merge, d))
+
+  if (expandEnv) {
+    require('dotenv-expand').expand({ ignoreProcessEnv: true, parsed: merge })
+  }
 
   const ajv = chooseAjvInstance(sharedAjvInstance, opts.ajv)
 

--- a/test/expand.test.js
+++ b/test/expand.test.js
@@ -46,6 +46,30 @@ const tests = [
     confExpected: {
       EXPANDED_VALUE_FROM_DOTENV: 'the password is password!'
     }
+  },
+  {
+    name: 'simple object - ok - expandEnv works when passed an arbitrary new object based on process.env as data',
+    schema: {
+      type: 'object',
+      properties: {
+        URL: {
+          type: 'string'
+        },
+        K8S_NAMESPACE: {
+          type: 'string'
+        }
+      }
+    },
+    expandEnv: true,
+    isOk: true,
+    data: {
+      ...process.env,
+      K8S_NAMESPACE: 'hello'
+    },
+    confExpected: {
+      URL: 'https://prefix.hello.pluto.my.domain.com',
+      K8S_NAMESPACE: 'hello'
+    }
   }
 ]
 


### PR DESCRIPTION
This pull request fixes a bug I encountered while using `env-schema`, which is reproduced here: https://github.com/serdnam/env-schema-expand-bug

I have added a test that failed prior to making the needed change and passes with said change, all other tests pass.

This is my first time contributing to the Fastify org, let me know if there is anything that I missed!

#### Checklist

- [✅] run `npm run test` and `npm run benchmark`
- [✅] tests and/or benchmarks are included
- [✅] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
