### PR TITLE
feat(index): support customOptions as object

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,24 @@ console.log(config)
 // output: { PORT: 3000 }
 ```
 
-It is possible to enhance the default ajv instance providing the `customOptions` function parameter.
+It is possible to enhance the default ajv instance providing the `customOptions` as a function or object parameter.
+
+When `customOptions` is an object, the provided ajv options override the default ones:
+
+```js
+const config = envSchema({
+  schema: schema,
+  data: data,
+  dotenv: true,
+  ajv: {
+    customOptions: {
+      coerceTypes: true
+    }
+  }
+})
+```
+
+When `customOptions` is a function, it must return the updated ajv instance.
 This example shows how to use the `format` keyword in your schemas.
 
 ```js
@@ -99,8 +116,6 @@ const config = envSchema({
   }
 })
 ```
-
-Note that it is mandatory to return the ajv instance.
 
 ### Order of configuration loading
 

--- a/index.js
+++ b/index.js
@@ -91,19 +91,22 @@ function envSchema (_opts) {
 }
 
 function chooseAjvInstance (defaultInstance, ajvOpts) {
-  if (!ajvOpts) {
-    return defaultInstance
-  } else if (typeof ajvOpts === 'object' && typeof ajvOpts.customOptions === 'function') {
-    const ajv = ajvOpts.customOptions(getDefaultInstance())
+  if (ajvOpts instanceof Ajv) {
+    return ajvOpts
+  }
+  let ajv = defaultInstance
+  if (typeof ajvOpts === 'object' && typeof ajvOpts.customOptions === 'function') {
+    ajv = ajvOpts.customOptions(getDefaultInstance())
     if (!(ajv instanceof Ajv)) {
       throw new TypeError('customOptions function must return an instance of Ajv')
     }
-    return ajv
+  } else if (typeof ajvOpts === 'object' && typeof ajvOpts.customOptions === 'object') {
+    ajv = getDefaultInstance(ajvOpts.customOptions)
   }
-  return ajvOpts
+  return ajv
 }
 
-function getDefaultInstance () {
+function getDefaultInstance (overrideOpts = {}) {
   return new Ajv({
     allErrors: true,
     removeAdditional: true,
@@ -111,7 +114,8 @@ function getDefaultInstance () {
     coerceTypes: true,
     allowUnionTypes: true,
     addUsedSchema: false,
-    keywords: [separator]
+    keywords: [separator],
+    ...overrideOpts
   })
 }
 

--- a/test/custom-ajv.test.js
+++ b/test/custom-ajv.test.js
@@ -298,8 +298,8 @@ const strictValidator = new Ajv({
 })
 
 test('ajv enhancement', async t => {
-  t.plan(2)
-  const testCase = {
+  t.plan(3)
+  const testCaseFn = {
     schema: {
       type: 'object',
       required: ['MONGODB_URL'],
@@ -316,11 +316,27 @@ test('ajv enhancement', async t => {
       MONGODB_URL: 'mongodb://localhost/pippo'
     }
   }
+  const testCaseObj = {
+    schema: {
+      type: 'object',
+      required: ['PORT'],
+      properties: {
+        PORT: {
+          type: 'string',
+        }
+      }
+    },
+    data: [{ PORT: 3333 }],
+    isOk: true,
+    confExpected: {
+      PORT: '3333'
+    }
+  }
 
-  await t.test('return', async t => {
+  await t.test('customOptions fn return', async t => {
     const options = {
-      schema: testCase.schema,
-      data: testCase.data,
+      schema: testCaseFn.schema,
+      data: testCaseFn.data,
       ajv: {
         customOptions (ajvInstance) {
           require('ajv-formats')(ajvInstance)
@@ -328,13 +344,13 @@ test('ajv enhancement', async t => {
         }
       }
     }
-    makeTest(t, options, testCase.isOk, testCase.confExpected)
+    makeTest(t, options, testCaseFn.isOk, testCaseFn.confExpected)
   })
 
-  await t.test('no return', async t => {
+  await t.test('customOptions fn no return', async t => {
     const options = {
-      schema: testCase.schema,
-      data: testCase.data,
+      schema: testCaseFn.schema,
+      data: testCaseFn.data,
       ajv: {
         customOptions (_ajvInstance) {
           // do nothing
@@ -342,5 +358,18 @@ test('ajv enhancement', async t => {
       }
     }
     makeTest(t, options, false, undefined, 'customOptions function must return an instance of Ajv')
+  })
+
+  await t.test('customOptions object override', async t => {
+    const options = {
+      schema: testCaseObj.schema,
+      data: testCaseObj.data,
+      ajv: {
+        customOptions: {
+          coerceTypes: true,
+        }
+      }
+    }
+    makeTest(t, options, testCaseObj.isOk, testCaseObj.confExpected)
   })
 })


### PR DESCRIPTION
This change introduce the ability to set `customOptions` as an object that will be used to override the default instance options.

This aligns with the behavior of Fastify regarding ajv configuration, and [fixes an issue with `fastify-cli`](https://github.com/fastify/demo/issues/119).

I've added a single test to ensure the ajv instance is passed the custom options. I updated the name of other tests in the `ajv enhancement` suite.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
