### PR TITLE
chore: remove rule eslint

### DIFF
--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -4,7 +4,6 @@ import envSchema, {
   EnvSchemaOpt,
   keywords,
   envSchema as envSchemaNamed,
-  // eslint-disable-next-line import-x/no-named-default -- Testing default export
   default as envSchemaDefault,
 } from '..'
 import Ajv, { KeywordDefinition, JSONSchemaType } from 'ajv'


### PR DESCRIPTION
Proposal:

- Removed rule eslint: `import-x/no-named-default` ( see screenshot or here: https://github.com/fastify/env-schema/actions/runs/24153625419/job/70487027843 for view error CI )


<img width="1441" height="258" alt="error-eslint" src="https://github.com/user-attachments/assets/84a59f93-d5ab-4745-b8fe-bb0cbb0b0134" />
